### PR TITLE
修正cloneRow方法在克隆表格行因找不到标签时导致生成的word文档office打不开的问题

### DIFF
--- a/PHPWord/Template.php
+++ b/PHPWord/Template.php
@@ -124,7 +124,7 @@ class PHPWord_Template {
 
         $tagPos = strpos($this->_documentXML, $search);
         if (!$tagPos) {
-            //throw new Exception("Can not clone row, template variable not found or variable contains markup.");
+            return false;
         }
 
         $rowStart = $this->findRowStart($tagPos);


### PR DESCRIPTION
表现形式：/word/document.xml　里面的XML多次重复循环，导致ＸＭＬ格式错乱，无法正常打开．